### PR TITLE
ignore "Given criteria don't match a window" error

### DIFF
--- a/i3-automark.py
+++ b/i3-automark.py
@@ -78,7 +78,13 @@ def refresh_all_marks(sock, marks):
 
     windows = itertools.chain.from_iterable(get_windows(tree, workspace) for workspace in visible_ws)
     for mark, id in zip(marks, windows):
-        send_msg(sock, 'run_command', '[con_id="{}"] mark --replace {}'.format(id, mark))
+        try:
+            send_msg(sock, 'run_command', '[con_id="{}"] mark --replace {}'.format(id, mark))
+        except Exception as e:
+            if str(e) == "Given criteria don't match a window":
+                pass
+            else:
+                raise
 
 def get_windows(node, workspace):
     if node['window']:


### PR DESCRIPTION
this exception (rarely) gets thrown when I open/re-arrange/move windows across workspaces

i'm not sure how to reliably replicate.

https://github.com/i3/i3/blob/aaee2b3eaefcb42414d72cbcf656eae06c3adb75/src/commands.c#L971-L975